### PR TITLE
Make root() static

### DIFF
--- a/src/Contracts/Tree/Tree.php
+++ b/src/Contracts/Tree/Tree.php
@@ -14,5 +14,5 @@ interface Tree
 
     public function children(): HasMany;
 
-    public function root(): Collection;
+    public static function root(): Collection;
 }


### PR DESCRIPTION
This PR makes the `root` function in Tree contract static