### PR TITLE
Fix casting empty array as objects

### DIFF
--- a/src/Content/ContentCast.php
+++ b/src/Content/ContentCast.php
@@ -107,6 +107,10 @@ abstract class ContentCast implements CastsAttributes, Arrayable, Jsonable
      */
     public function toArray()
     {
+        if (empty($this->items)) {
+            return new \stdClass;
+        }
+
         foreach ($this->items as $key => $item) {
             if (! is_array($item)) {
                 continue;


### PR DESCRIPTION
This PR adds a solution for casted attributes which are created with an default empty array:

```php
    protected $attributes = [
        'attributes' => '[]',
    ];
```


and therefore must be transformed in order to be editable.
@jannescb added a workaround in 
https://github.com/macramejs/admin-vue3/commit/9ce3cb64ebeee3a5d52c4b8e59019e0fbb613dff

```js
        if (Array.isArray(page.attributes)) {
            page.attributes = {};
        }
```

However this makes the form dirty immediately, even no content was changed yet.

This solution directly casts the empty array to an empty object  `{}` .