### PR TITLE
Add perPage parameter

### DIFF
--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -108,7 +108,6 @@ abstract class Index implements IndexContract
         return $this->defaultPerPage;
     }
 
-
     protected function getFiltersFromRequest(Request $request)
     {
         return collect($request->all())

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -90,10 +90,24 @@ abstract class Index implements IndexContract
             call_user_func_array([$this, 'sort'], [$query, $this->getOrderFromRequest($request)]);
         }
 
-        $items = $query->paginate($this->defaultPerPage);
+        if (($perPage = $this->getItemsPerPage($request)) == -1) {
+            $items = $query->get();
+        } else {
+            $items = $query->paginate($perPage);
+        }
 
         return $resource::collection($items);
     }
+
+    protected function getItemsPerPage(Request $request)
+    {
+        if ($request->perPage) {
+            return $request->perPage;
+        }
+
+        return $this->defaultPerPage;
+    }
+
 
     protected function getFiltersFromRequest(Request $request)
     {


### PR DESCRIPTION
Currently the amount of items loaded per page is hard coded within the entity index class in php.

This works well for most situations, however if we want to use an index of an entity within a Select component, it's inconvenient that this number  is only globally changable. 

With this PR we can provide a request param `perPage` to adjust the number of loaded items per Page with a special option using `-1` to disable pagination completely:

```ts
export const entityState = useState<Entity[]>([], {
    load: () => loadEntity({
        perPage: -1 //or any positive value
    }),
});
```

The `defaultPerPage` defined in the EnityIndex class will allways be used as a fallback.